### PR TITLE
resource/aws_ecs_service: Add EXTERNAL deployment_controller argument

### DIFF
--- a/aws/resource_aws_ecs_service.go
+++ b/aws/resource_aws_ecs_service.go
@@ -43,7 +43,7 @@ func resourceAwsEcsService() *schema.Resource {
 
 			"task_definition": {
 				Type:     schema.TypeString,
-				Required: true,
+				Optional: true,
 			},
 
 			"desired_count": {
@@ -118,6 +118,7 @@ func resourceAwsEcsService() *schema.Resource {
 							ValidateFunc: validation.StringInSlice([]string{
 								ecs.DeploymentControllerTypeCodeDeploy,
 								ecs.DeploymentControllerTypeEcs,
+								ecs.DeploymentControllerTypeExternal,
 							}, false),
 						},
 					},
@@ -357,10 +358,11 @@ func resourceAwsEcsServiceCreate(d *schema.ResourceData, meta interface{}) error
 
 	deploymentMinimumHealthyPercent := d.Get("deployment_minimum_healthy_percent").(int)
 	schedulingStrategy := d.Get("scheduling_strategy").(string)
+	deploymentController := expandEcsDeploymentController(d.Get("deployment_controller").([]interface{}))
 
 	input := ecs.CreateServiceInput{
 		ClientToken:          aws.String(resource.UniqueId()),
-		DeploymentController: expandEcsDeploymentController(d.Get("deployment_controller").([]interface{})),
+		DeploymentController: deploymentController,
 		SchedulingStrategy:   aws.String(schedulingStrategy),
 		ServiceName:          aws.String(d.Get("name").(string)),
 		Tags:                 tagsFromMapECS(d.Get("tags").(map[string]interface{})),
@@ -390,6 +392,13 @@ func resourceAwsEcsServiceCreate(d *schema.ResourceData, meta interface{}) error
 
 	if v, ok := d.GetOk("launch_type"); ok {
 		input.LaunchType = aws.String(v.(string))
+		// When creating a service that uses the EXTERNAL deployment controller,
+		// you can specify only parameters that aren't controlled at the task set level
+		// hence you cannot set LaunchType, not changing the default launch_type from EC2 to empty
+		// string to have backward compatibility
+		if deploymentController != nil && aws.StringValue(deploymentController.Type) == ecs.DeploymentControllerTypeExternal {
+			input.LaunchType = aws.String("")
+		}
 	}
 
 	if v, ok := d.GetOk("propagate_tags"); ok {
@@ -560,12 +569,17 @@ func resourceAwsEcsServiceRead(d *schema.ResourceData, meta interface{}) error {
 	d.SetId(*service.ServiceArn)
 	d.Set("name", service.ServiceName)
 
-	// Save task definition in the same format
-	if strings.HasPrefix(d.Get("task_definition").(string), "arn:"+meta.(*AWSClient).partition+":ecs:") {
-		d.Set("task_definition", service.TaskDefinition)
-	} else {
-		taskDefinition := buildFamilyAndRevisionFromARN(*service.TaskDefinition)
-		d.Set("task_definition", taskDefinition)
+	// When creating a service that uses the EXTERNAL deployment controller,
+	// you can specify only parameters that aren't controlled at the task set level
+	// hence TaskDefinition will not be set by aws sdk
+	if service.TaskDefinition != nil {
+		// Save task definition in the same format
+		if strings.HasPrefix(d.Get("task_definition").(string), "arn:"+meta.(*AWSClient).partition+":ecs:") {
+			d.Set("task_definition", service.TaskDefinition)
+		} else {
+			taskDefinition := buildFamilyAndRevisionFromARN(*service.TaskDefinition)
+			d.Set("task_definition", taskDefinition)
+		}
 	}
 
 	d.Set("scheduling_strategy", service.SchedulingStrategy)

--- a/website/docs/r/ecs_service.html.markdown
+++ b/website/docs/r/ecs_service.html.markdown
@@ -72,16 +72,26 @@ resource "aws_ecs_service" "bar" {
 }
 ```
 
+### External Deployment Controller
+
+```hcl
+resource "aws_ecs_service" "foo" {
+  name                  = "foo"
+  cluster               = "${aws_ecs_cluster.foo.id}"
+  deployment_controller = "EXTERNAL"
+}
+```
+
 ## Argument Reference
 
 The following arguments are supported:
 
 * `name` - (Required) The name of the service (up to 255 letters, numbers, hyphens, and underscores)
-* `task_definition` - (Required) The family and revision (`family:revision`) or full ARN of the task definition that you want to run in your service.
+* `task_definition` - (Optional) The family and revision (`family:revision`) or full ARN of the task definition that you want to run in your service. If a revision is not specified, the latest `ACTIVE` revision is used. Note that a task definition must be specified if the service is using the `ECS` deployment controller.
 * `desired_count` - (Optional) The number of instances of the task definition to place and keep running. Defaults to 0. Do not specify if using the `DAEMON` scheduling strategy.
 * `launch_type` - (Optional) The launch type on which to run your service. The valid values are `EC2` and `FARGATE`. Defaults to `EC2`.
 * `platform_version` - (Optional) The platform version on which to run your service. Only applicable for `launch_type` set to `FARGATE`. Defaults to `LATEST`. More information about Fargate platform versions can be found in the [AWS ECS User Guide](https://docs.aws.amazon.com/AmazonECS/latest/developerguide/platform_versions.html).
-* `scheduling_strategy` - (Optional) The scheduling strategy to use for the service. The valid values are `REPLICA` and `DAEMON`. Defaults to `REPLICA`. Note that [*Fargate tasks do not support the `DAEMON` scheduling strategy*](https://docs.aws.amazon.com/AmazonECS/latest/developerguide/scheduling_tasks.html).
+* `scheduling_strategy` - (Optional) The scheduling strategy to use for the service. The valid values are `REPLICA` and `DAEMON`. Defaults to `REPLICA`. Note that [*Tasks using the Fargate launch type or the `CODE_DEPLOY` or `EXTERNAL` deployment controller types don't support the `DAEMON` scheduling strategy*](https://docs.aws.amazon.com/AmazonECS/latest/APIReference/API_CreateService.html).
 * `cluster` - (Optional) ARN of an ECS cluster
 * `iam_role` - (Optional) ARN of the IAM role that allows Amazon ECS to make calls to your load balancer on your behalf. This parameter is required if you are using a load balancer with your service, but only if your task definition does not use the `awsvpc` network mode. If using `awsvpc` network mode, do not specify this role. If your account has already created the Amazon ECS service-linked role, that role is used by default for your service unless you specify a role here.
 * `deployment_controller` - (Optional) Configuration block containing deployment controller configuration. Defined below.
@@ -102,7 +112,7 @@ The following arguments are supported:
 
 The `deployment_controller` configuration block supports the following:
 
-* `type` - (Optional) Type of deployment controller. Valid values: `CODE_DEPLOY`, `ECS`. Default: `ECS`.
+* `type` - (Optional) Type of deployment controller. Valid values: `CODE_DEPLOY`, `ECS`, `EXTERNAL`. Default: `ECS`.
 
 ## load_balancer
 


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/terraform-providers/terraform-provider-aws/blob/master/.github/CONTRIBUTING.md#pull-requests --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" comments, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

Fixes #0000

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note

```

Output from acceptance testing:

```
$ make testacc TESTARGS='-run=TestAccXXX'

...
```
